### PR TITLE
[mod] css pour permettre l'utilisation dans le menu de la barre d'outils (ff 57+)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -105,7 +105,8 @@ a.more:after, .button.more:after{
 
 .decodex{
 	font-size: 0.875em;
-	width: 419px;
+	width: 100%;
+	max-width: 419px;
 	border-radius: 2px;
 	background-color: #ffffff;
 	box-shadow: 0 2px 10px 0 #8b9299;
@@ -184,7 +185,7 @@ input[type="checkbox"]:checked {
 
 
 footer {
-  width: 419px;
+  width: 100%;
   height: 47px;
   background-color: #eef1f5;
 }


### PR DESCRIPTION
Quand l'extension se trouve dans le menu prolongeant la barre d'outil de Firefox dans les versions 57 et supérieures, les 419px du popup sont trop larges.
Changement des
```css
{
    ...
    width: 419px;
    ...
}
```
en
```css
{
    ...
    width: 100%;
    max-width: 419px;
    ...
}
```
pour s'adapter à ce cas.